### PR TITLE
add postgres blob storage provider with optional dep on pgsql

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,12 @@ containerInfo:
   - image: tsloughter/erlang-git:19.3-2
     cmd: ["/bin/bash"]
 
+  - image: postgres:9
+    env:
+      - POSTGRES_USER=test
+      - POSTGRES_PASSWORD=test
+      - POSTGRES_DB=test
+
 stages:
   build:
     workDir: ~/erleans
@@ -27,6 +33,8 @@ stages:
             rebar3 xref
             rebar3 dialyzer
             rebar3 ci
+
+            rebar3 as pg ci
 
       - type: test-results-store
         path: ~/erleans/_build/test/logs/

--- a/config/sys.config
+++ b/config/sys.config
@@ -1,5 +1,11 @@
 %% -*- erlang -*-
-[{erleans, [{providers, []},
+[{erleans, [{providers, [{name1, [{module, erleans_pgsql_blob_provider},
+                                  {pool_size, 5},
+                                  {args, [{host, "0.0.0.0"},
+                                          {port, 5432},
+                                          {database, "test"},
+                                          {user, "test"},
+                                          {password, ""}]}]}]},
             {default_provider, ets_provider}]},
 
  {lasp, [{storage_backend, lasp_ets_storage_backend},

--- a/rebar.config
+++ b/rebar.config
@@ -5,17 +5,29 @@
         lasp_pg,
         gproc,
         sbroker,
+        backoff,
         erlware_commons,
         types,
         hash_ring,
         {uuid, {pkg, uuid_erl}}]}.
 
+{profiles, [{pg, [{deps, [pgsql]},
+                  {ct_opts, [{sys_config, "test/postgres_sys.config"}]}]}]}.
+
+{ct_opts, [{sys_config, "test/sys.config"}]}.
+
 {plugins, [rebar_alias]}.
-{alias, [{test, [{ct, "--sname ct --sys_config=test/sys.config"}]},
-         {ci, [{ct, "--sname ct --sys_config=test/sys.config --suite=test/grain_lifecycle_SUITE,test/grain_streams_SUITE,test/stateless_grain_SUITE"}]}]}.
+{alias, [{test, [{ct, "--sname ct"}]},
+         {ci, [{ct, "--sname ct --suite=test/grain_lifecycle_SUITE,test/grain_streams_SUITE,test/stateless_grain_SUITE"}]}]}.
 
 {shell, [{apps, [erleans]},
          {config, "config/sys.config"}]}.
 
 {xref_checks, [undefined_function_calls, undefined_functions,
                deprecated_function_calls, deprecated_functions]}.
+
+%% pgsql is an optional dependency
+{xref_ignores, [{pgsql_connection,extended_query,3},
+                {pgsql_connection,close,1},
+                {pgsql_connection,open,1},
+                {pgsql_connection,simple_query,2}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,5 +1,6 @@
 {"1.1.0",
 [{<<"acceptor_pool">>,{pkg,<<"acceptor_pool">>,<<"1.0.0-rc.0">>},2},
+ {<<"backoff">>,{pkg,<<"backoff">>,<<"1.1.3">>},0},
  {<<"cf">>,{pkg,<<"cf">>,<<"0.2.2">>},1},
  {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"1.0.0">>},0},
  {<<"gen_flow">>,{pkg,<<"gen_flow">>,<<"0.0.3">>},1},
@@ -23,6 +24,7 @@
 [
 {pkg_hash,[
  {<<"acceptor_pool">>, <<"679D741DF87FC13599B1AEF2DF8F78F1F880449A6BEFAB7C44FB6FAE0E92A2DE">>},
+ {<<"backoff">>, <<"DE762C05ED6DFAE862D83DC9E58AE936792B01302B3595F5CFFE86F2D8E6C1DD">>},
  {<<"cf">>, <<"7F2913FFF90ABCABD0F489896CFEB0B0674F6C8DF6C10B17A83175448029896C">>},
  {<<"erlware_commons">>, <<"087467DE5833C0BB5B3CCDD387F9E9C1FB816A75B7A709629BF24B5ED3246C51">>},
  {<<"gen_flow">>, <<"639F5C3F52DC3F7459542DE3F72D5BFF11EB7DB8FB055657A3011F9A70FCF0D7">>},

--- a/src/erleans_conn_manager.erl
+++ b/src/erleans_conn_manager.erl
@@ -1,0 +1,156 @@
+%%%----------------------------------------------------------------------------
+%%% Copyright Space-Time Insight 2017. All Rights Reserved.
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%----------------------------------------------------------------------------
+
+%%% ---------------------------------------------------------------------------
+%%% @doc
+%%% @end
+%%% ---------------------------------------------------------------------------
+-module(erleans_conn_manager).
+
+-behaviour(gen_server).
+
+-export([start_link/4,
+         get_connection/1,
+         done/2]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-dialyzer({nowarn_function, enqueue_connection/3}).
+-dialyzer({nowarn_function, connect/5}).
+
+-record(state, {mod       :: module(),
+                conn_args :: list(),
+                conns     :: #{pid() => reference() | undefined},
+                monitors  :: #{reference() => pid()},
+                broker    :: sbroker:broker(),
+                pool_size :: integer(),
+                backoff   :: backoff:backoff()}).
+
+-include("erleans.hrl").
+
+-spec start_link(module(), atom(), integer(), list()) -> {ok, pid()} | {error, any()}.
+start_link(Mod, Broker, Size, Args) ->
+    gen_server:start_link({local, Broker}, ?MODULE, [Mod, Broker, Size, Args], []).
+
+get_connection(Broker) ->
+    case sbroker:ask(?broker(Broker)) of
+        {go, _Ref, Pid, _RelativeTime, _SojournTime} ->
+            Pid;
+        {drop, _N} ->
+            {error, timeout}
+    end.
+
+
+done(Broker, Pid) ->
+    enqueue_connection(Broker, Pid, whereis(Broker)),
+    gen_server:cast(Broker, {done, Pid}).
+
+init([Mod, Broker, Size, Args]) ->
+    erlang:process_flag(trap_exit, true),
+    B = backoff:init(1000, 10000, self(), backoff_fired),
+    {ok, #state{mod=Mod,
+                conns=#{},
+                monitors=#{},
+                broker=Broker,
+                conn_args=Args,
+                pool_size=Size,
+                backoff=B}, 0}.
+
+handle_call(_, _From, State) ->
+    {noreply, State}.
+
+handle_cast({done, Pid}, State=#state{mod=Mod,
+                                      conns=Conns}) ->
+    case maps:get(Pid, Conns, undefined) of
+        undefined ->
+            %% should never happen. just close this maybe open connection
+            catch Mod:close(Pid),
+            {noreply, State#state{conns=Conns#{Pid => undefined}}};
+        Monitor ->
+            erlang:demonitor(Monitor, [flush]),
+            {noreply, State#state{conns=Conns#{Pid => undefined}}}
+    end.
+
+handle_info({Conn, {go, _Ref, Pid, _, _}}, State=#state{conns=Conns,
+                                                        monitors=Monitors}) ->
+    Mon = erlang:monitor(process, Pid),
+    {noreply, State#state{conns=Conns#{Conn => Mon},
+                          monitors=Monitors#{Mon => Conn}}};
+handle_info({Conn, {drop, _}}, State=#state{broker=Broker,
+                                           conns=Conns}) ->
+    enqueue_connection(Broker, Conn, self()),
+    {noreply, State#state{conns=Conns#{Conn => undefined}}};
+handle_info({'DOWN', Ref, process, _Pid, _}, State=#state{mod=Mod,
+                                                          conns=Conns,
+                                                          monitors=Monitors}) ->
+    erlang:demonitor(Ref, [flush]),
+    {Conn, Monitors1} = maps:take(Ref, Monitors),
+    %% closing will trigger the handle_info EXIT call to handle reconnecting
+    Mod:close(Conn),
+    {noreply, State#state{conns=maps:remove(Conn, Conns),
+                          monitors=Monitors1}};
+handle_info({'EXIT', Pid, _}, State=#state{mod=Mod,
+                                           conn_args=Args,
+                                           conns=Conns,
+                                           broker=Broker,
+                                           backoff=B}) ->
+    cancel(Broker, Pid),
+    {B1, Conns1} = connect(Mod, Args, Broker, Conns, B),
+    {noreply, State#state{conns=Conns1,
+                          backoff=B1}};
+handle_info(timeout, State=#state{mod=Mod,
+                                  broker=Broker,
+                                  conn_args=Args,
+                                  conns=Conns,
+                                  pool_size=Size,
+                                  backoff=B}) ->
+    {B2, Conns1} = lists:foldl(fun(_, {BAcc, ConnsAcc}) ->
+                                   connect(Mod, Args, Broker, ConnsAcc, BAcc)
+                              end, {B, Conns}, lists:seq(1, Size)),
+    {noreply, State#state{conns=Conns1,
+                          backoff=B2}}.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+%%%
+
+connect(Mod, Args, Broker, Conns, B) ->
+    case Mod:connect(Args) of
+        {ok, Pid} ->
+            erlang:link(Pid),
+            {await, _, _} = enqueue_connection(Broker, Pid, self()),
+            {_, B1} = backoff:succeed(B),
+            {B1, Conns#{Pid => undefined}};
+        _ ->
+            _ = backoff:fire(B),
+            {_, B1} = backoff:fail(B),
+            {B1, Conns}
+    end.
+
+cancel(Broker, Tag) ->
+    sbroker:dirty_cancel(?broker(Broker), Tag).
+
+enqueue_connection(Broker, Pid, ToPid) ->
+    sbroker:async_ask_r(?broker(Broker), Pid, {ToPid, Pid}).

--- a/src/erleans_pgsql_blob_provider.erl
+++ b/src/erleans_pgsql_blob_provider.erl
@@ -1,0 +1,134 @@
+%%%----------------------------------------------------------------------------
+%%% Copyright Space-Time Insight 2017. All Rights Reserved.
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%----------------------------------------------------------------------------
+
+%%% ---------------------------------------------------------------------------
+%%% @doc
+%%% @end
+%%% ---------------------------------------------------------------------------
+-module(erleans_pgsql_blob_provider).
+
+-behaviour(erleans_provider).
+
+-export([init/2,
+         post_init/2,
+         connect/1,
+         close/1,
+         all/2,
+         read/3,
+         insert/5,
+         replace/6]).
+
+init(_ProviderName, Args) ->
+    {pool, Args}.
+
+post_init(ProviderName, _Args) ->
+    do(ProviderName, fun(C) -> create_grains_table(C) end).
+
+connect(Args) ->
+    case pgsql_connection:open(Args) of
+        {pgsql_connection, Pid} ->
+            {ok, Pid};
+        {error, Reason} ->
+            lager:error("pgsql_connection:open failed reason=~p", [Reason]),
+            error
+    end.
+
+close(Pid) ->
+    pgsql_connection:close({pgsql_connection, Pid}).
+
+all(Type, ProviderName) ->
+    do(ProviderName, fun(C) -> all_(Type, C) end).
+
+read(Type, ProviderName, Id) ->
+    do(ProviderName, fun(C) ->
+                         case read(Id, Type, erlang:phash2({Id, Type}), C) of
+                             {ok, {_, _, ETag, State}} ->
+                                 {ok, binary_to_term(State), ETag};
+                             error ->
+                                 not_found
+                         end
+                     end).
+
+insert(Type, ProviderName, Id, State, ETag) ->
+    do(ProviderName, fun(C) -> insert(Id, Type, erlang:phash2({Id, Type}), ETag, State, C) end).
+
+replace(Type, ProviderName, Id, State, OldETag, NewETag) ->
+    do(ProviderName, fun(C) -> replace(Id, Type, erlang:phash2({Id, Type}), OldETag, NewETag, State, C) end).
+
+%%%
+
+do(ProviderName, Fun) ->
+    C = erleans_conn_manager:get_connection(ProviderName),
+    try
+        Fun(C)
+    after
+        erleans_conn_manager:done(ProviderName, C)
+    end.
+
+create_grains_table(C) ->
+    {{create,table},[]} = pgsql_connection:simple_query(["CREATE TABLE IF NOT EXISTS erleans_grains ( "
+                                                        "  grain_id BYTEA NOT NULL, ", % CHARACTER VARYING(2048), "
+                                                        "  grain_type CHARACTER VARYING(2048), "
+                                                        "  grain_ref_hash BIGINT NOT NULL, "
+                                                        "  grain_etag BIGINT NOT NULL, "
+                                                        "  grain_state BYTEA NOT NULL, "
+                                                        "  change_time TIMESTAMP NOT NULL,"
+                                                        "  PRIMARY KEY (grain_id, grain_type))"], {pgsql_connection, C}),
+    pgsql_connection:simple_query(["CREATE INDEX IF NOT EXISTS ",
+                                   "erleans_grains_term_idx ON erleans_grains USING HASH (grain_state)"], {pgsql_connection, C}).
+
+all_(Type, C) ->
+    Q = ["SELECT grain_id, grain_etag, grain_state ",
+         "FROM erleans_grains WHERE grain_type = $1"],
+    {{select, _}, Rows} = pgsql_connection:extended_query(Q, [atom_to_binary(Type, utf8)], {pgsql_connection, C}),
+    {ok, [{binary_to_term(IdBin), Type, ETag, binary_to_term(StateBin)}
+         || {IdBin, ETag, StateBin} <- Rows]}.
+
+
+read(Id, Type, RefHash, C) ->
+    Q = ["SELECT grain_id, grain_type, grain_etag, grain_state ",
+         "FROM erleans_grains WHERE grain_ref_hash = $1"],
+    RefHash = erlang:phash2({Id, Type}),
+    {{select, _}, Rows} = pgsql_connection:extended_query(Q, [RefHash],
+                                                          {pgsql_connection, C}),
+    IdBin = term_to_binary(Id),
+    TypeBin = atom_to_binary(Type, utf8),
+    ec_lists:find(fun({RowId, RowType, _, _}) when IdBin =:= RowId
+                                                 , TypeBin =:= RowType-> true;
+                     (_) ->
+                      false
+                  end, Rows).
+
+insert(Id, Type, RefHash, GrainETag, GrainState, C) ->
+    Q = ["INSERT INTO erleans_grains (grain_id, grain_type, grain_ref_hash, grain_etag, grain_state, change_time) VALUES ",
+         "($1, $2, $3, $4, $5, CURRENT_TIMESTAMP)"],
+    IdBin = term_to_binary(Id),
+    {{insert, _, 1}, []} = pgsql_connection:extended_query(Q, [IdBin, atom_to_binary(Type, utf8), RefHash,
+                                                               GrainETag, term_to_binary(GrainState)],
+                                                           {pgsql_connection, C}).
+
+replace(Id, Type, RefHash, OldGrainETag, NewGrainETag, GrainState, C) ->
+    Q = ["UPDATE erleans_grains SET grain_etag = $1, grain_state = $2, change_time = CURRENT_TIMESTAMP ",
+         "WHERE grain_ref_hash = $3 AND grain_id = $4 AND grain_type = $5 AND grain_etag = $6"],
+    IdBin = term_to_binary(Id),
+    case pgsql_connection:extended_query(Q, [NewGrainETag, term_to_binary(GrainState), RefHash, IdBin,
+                                             atom_to_binary(Type, utf8), OldGrainETag],
+                                         {pgsql_connection, C}) of
+        {{update, 1}, []} ->
+            ok;
+        {{update, 0}, []} ->
+            {error, bad_etag}
+    end.

--- a/src/erleans_provider.erl
+++ b/src/erleans_provider.erl
@@ -20,34 +20,27 @@
 %%% ---------------------------------------------------------------------------
 -module(erleans_provider).
 
--export([all/1,
-         insert/4,
-         replace/5]).
+-callback init(ProviderName :: atom(), Args :: list()) -> ok | {pool, Args :: list()}.
 
--callback init(list()) -> ok.
+-callback all(Type :: module(), ProviderName :: atom()) -> {ok, [any()]} | {error, any()}.
 
--callback all(Type :: module()) -> {ok, [any()]} | {error, any()}.
+-callback read(Type :: module(), ProviderName :: atom(), GrainRef :: erleans:grain_ref()) ->
+    {ok, State :: any(), ETag :: erleans:etag()} |
+    {error, not_found}.
 
--callback read(Type :: module(), GrainRef :: erleans:grain_ref()) -> {ok, State :: any(), ETag :: erleans:etag()} |
-                                                                     {error, not_found}.
+-callback insert(Type :: module(), ProviderName :: atom(), Id :: any(), State :: any(), ETag :: erleans:etag()) -> ok.
 
--callback insert(Type :: module(), Id :: any(), State :: any(), ETag :: erleans:etag()) -> ok.
-
--callback update(Type :: module(), Id :: any(), Update :: list(), ETag :: erleans:etag(), NewETag :: erleans:etag()) ->
+-callback update(Type :: module(), ProviderName :: atom(), Id :: any(), Update :: list(),
+                 ETag :: erleans:etag(), NewETag :: erleans:etag()) ->
     ok |
     {error, {bad_etag, erleans:etag(), erleans:etag()}} |
     {error, not_found}.
 
--callback replace(Type :: module(), Id :: any(), State :: any(), ETag :: erleans:etag(), NewETag :: erleans:etag()) ->
+%% Not all backends are going to be able to provide per-field update functionality
+-optional_callbacks([update/6]).
+
+-callback replace(Type :: module(), ProviderName :: atom(), Id :: any(), State :: any(),
+                  ETag :: erleans:etag(), NewETag :: erleans:etag()) ->
     ok |
     {error, {bad_etag, erleans:etag(), erleans:etag()}} |
     {error, not_found}.
-
-all(Type) ->
-    (Type:provider()):all(Type).
-
-insert(Type, Id, State, ETag) ->
-    (Type:provider()):insert(Type, Id, State, ETag).
-
-replace(Type, Id, State, ETag, NewETag) ->
-    (Type:provider()):replace(Type, Id, State, ETag, NewETag).

--- a/src/erleans_provider_pool.erl
+++ b/src/erleans_provider_pool.erl
@@ -1,0 +1,41 @@
+%%%----------------------------------------------------------------------------
+%%% Copyright Space-Time Insight 2017. All Rights Reserved.
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%----------------------------------------------------------------------------
+
+%%% ---------------------------------------------------------------------------
+%%% @doc
+%%% @end
+%%% ---------------------------------------------------------------------------
+-module(erleans_provider_pool).
+
+-export([start_link/1]).
+
+-export([init/1]).
+
+-include("erleans.hrl").
+
+start_link(Name) ->
+    sbroker:start_link(?broker(Name), ?MODULE, [], [{read_time_after, 16}]).
+
+init(_) ->
+    QueueSpec = {sbroker_timeout_queue, #{out => out,
+                                          timeout => 5000,
+                                          drop => drop_r,
+                                          min => 0,
+                                          max => 128}},
+    WorkerSpec = {sbroker_drop_queue, #{out => out,
+                                        drop => drop,
+                                        max => infinity}},
+    {ok, {QueueSpec, WorkerSpec, []}}.

--- a/src/erleans_provider_pool_sup.erl
+++ b/src/erleans_provider_pool_sup.erl
@@ -1,0 +1,60 @@
+%%%----------------------------------------------------------------------------
+%%% Copyright Space-Time Insight 2017. All Rights Reserved.
+%%%
+%%% Licensed under the Apache License, Version 2.0 (the "License");
+%%% you may not use this file except in compliance with the License.
+%%% You may obtain a copy of the License at
+%%%
+%%%     http://www.apache.org/licenses/LICENSE-2.0
+%%%
+%%% Unless required by applicable law or agreed to in writing, software
+%%% distributed under the License is distributed on an "AS IS" BASIS,
+%%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%%% See the License for the specific language governing permissions and
+%%% limitations under the License.
+%%%----------------------------------------------------------------------------
+
+%%% ---------------------------------------------------------------------------
+%%% @doc
+%%% @end
+%%% ---------------------------------------------------------------------------
+-module(erleans_provider_pool_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/2]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+%%====================================================================
+%% API functions
+%%====================================================================
+
+start_link(Name, Config) ->
+    supervisor:start_link(?MODULE, [Name, Config]).
+
+%%====================================================================
+%% Supervisor callbacks
+%%====================================================================
+
+%% Child :: {Id,StartFunc,Restart,Shutdown,Type,Modules}
+init([Name, Config]) ->
+    Size = proplists:get_value(pool_size, Config, 5),
+    Module = proplists:get_value(module, Config),
+    Options = proplists:get_value(args, Config, []),
+
+    Broker = {erleans_provider_broker, {erleans_provider_pool, start_link, [Name]},
+              permanent, 5000, worker, [erleans_provider_pool]},
+    ConnManager = {{erleans_conn_manager, Name}, {erleans_conn_manager, start_link, [Module, Name, Size, Options]},
+                   permanent, 5000, worker, [nucleus_provider_worker]},
+
+
+    {ok, {{one_for_one, 5, 10}, [Broker, ConnManager]}}.
+
+%%====================================================================
+%% Internal functions
+%%====================================================================

--- a/src/erleans_sup.erl
+++ b/src/erleans_sup.erl
@@ -23,17 +23,17 @@
 
 -behaviour(supervisor).
 
--export([start_link/0]).
+-export([start_link/1]).
 
 -export([init/1]).
 
 -define(SERVER, ?MODULE).
 
--spec start_link() -> {ok, pid()}.
-start_link() ->
-    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+-spec start_link(list()) -> {ok, pid()}.
+start_link(ProviderPoolSpecs) ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, [ProviderPoolSpecs]).
 
-init([]) ->
+init([ProviderPools]) ->
     SupFlags = #{strategy => one_for_one,
                  intensity => 0,
                  period => 1},
@@ -61,7 +61,7 @@ init([]) ->
                     start => {erleans_stream_manager, start_link, []},
                     restart => permanent,
                     type => worker,
-                    shutdown => 5000}],
+                    shutdown => 5000} | ProviderPools],
     {ok, {SupFlags, ChildSpecs}}.
 
 %%====================================================================

--- a/test/grain_streams_SUITE.erl
+++ b/test/grain_streams_SUITE.erl
@@ -18,6 +18,7 @@ all() ->
     [simple_subscribe].
 
 init_per_suite(Config) ->
+    application:ensure_all_started(pgsql),
     application:load(erleans),
     application:set_env(erleans, default_lease_time, 60000),
     {ok, _} = application:ensure_all_started(erleans),
@@ -25,6 +26,7 @@ init_per_suite(Config) ->
 
 end_per_suite(_Config) ->
     application:stop(erleans),
+    application:stop(pgsql),
     ok.
 
 init_per_testcase(_, Config) ->

--- a/test/postgres_sys.config
+++ b/test/postgres_sys.config
@@ -1,0 +1,24 @@
+%% -*- erlang -*-
+[{erleans, [{grain_provider, [{test_grain, postgres}]},
+            {providers, [{ets, [{module, ets_provider},
+                                {args, []}]},
+                         {postgres, [{module, erleans_pgsql_blob_provider},
+                                     {pool_size, 5},
+                                     {args, [{host, "0.0.0.0"},
+                                             {port, 5432},
+                                             {database, "test"},
+                                             {user, "test"},
+                                             {password, "test"}]}]}]},
+            {default_provider, postgres}]},
+
+ {lasp, [{storage_backend, lasp_ets_storage_backend},
+         {mode, delta_based},
+         {delta_interval, 200}]},
+
+ {plumtree, [{broadcast_exchange_timer, 60000},
+             {broadcast_mods, [lasp_plumtree_backend]}]},
+
+ {partisan, [{peer_port, 10200},
+             {partisan_peer_service_manager,
+              partisan_default_peer_service_manager}]}
+].

--- a/test/stateless_grain_SUITE.erl
+++ b/test/stateless_grain_SUITE.erl
@@ -18,12 +18,14 @@ all() ->
     [limits].
 
 init_per_suite(Config) ->
+    application:ensure_all_started(pgsql),
     application:load(erleans),
     {ok, _} = application:ensure_all_started(erleans),
     Config.
 
 end_per_suite(_Config) ->
     application:stop(erleans),
+    application:stop(pgsql),
     ok.
 
 init_per_testcase(_, Config) ->

--- a/test/stateless_test_grain.erl
+++ b/test/stateless_test_grain.erl
@@ -30,7 +30,7 @@ placement() ->
     {stateless, 3}.
 
 provider() ->
-    ets_provider.
+    ets.
 
 deactivated_counter(Ref) ->
     erleans_grain:call(Ref, deactivated_counter).

--- a/test/stream_test_grain.erl
+++ b/test/stream_test_grain.erl
@@ -26,13 +26,13 @@ placement() ->
     prefer_local.
 
 provider() ->
-    ets_provider.
+    erleans_config:get(default_provider).
 
 records_read(Ref) ->
     erleans_grain:call(Ref, records_read).
 
-init(_, State=#{}) ->
-    Topic = <<"some-topic">>,
+init(#{id := Id}, State=#{}) ->
+    Topic = <<Id/binary, "-some-topic">>,
     StreamProvider = test_stream,
     erleans_grain:subscribe(StreamProvider, Topic),
     {ok, State, #{life_time => infinity}}.

--- a/test/sys.config
+++ b/test/sys.config
@@ -1,6 +1,8 @@
 %% -*- erlang -*-
-[{erleans, [{providers, [{ets_provider, []}]},
-            {default_provider, ets_provider}]},
+[{erleans, [{grain_provider, [{test_grain, postgres}]},
+            {providers, [{ets, [{module, ets_provider},
+                                {args, []}]}]},
+            {default_provider, ets}]},
 
  {lasp, [{storage_backend, lasp_ets_storage_backend},
          {mode, delta_based},

--- a/test/test_ephemeral_state_grain.erl
+++ b/test/test_ephemeral_state_grain.erl
@@ -36,7 +36,7 @@ placement() ->
     prefer_local.
 
 provider() ->
-    ets_provider.
+    ets.
 
 deactivated_counter(Ref) ->
     erleans_grain:call(Ref, deactivated_counter).

--- a/test/test_grain.erl
+++ b/test/test_grain.erl
@@ -29,7 +29,7 @@ placement() ->
     prefer_local.
 
 provider() ->
-    ets_provider.
+    erleans_config:get(default_provider).
 
 deactivated_counter(Ref) ->
     erleans_grain:call(Ref, deactivated_counter).


### PR DESCRIPTION
This commit adds a basic blob based postgres grain storage provider. "Blob based" means it stores the grain state as a simple `bytea` column using `term_to_binary/1`.

How providers are configured changed slightly in this PR. Instead of `provider/0` returning the module of the provider it must now return the name. This maps to a configuration of the provider in the application environment, which must include the tuple `{module, module()}` to specify the provider module implementation for this provider, allowing for multiple providers to use the same implementation but with different configurations.

It also adds a simple connection pooling functionality that erleans will automatically startup if the provider's `init` function returns `{pool, list()}`.