### PR TITLE
use module_info instead of function_exports

### DIFF
--- a/src/erleans.erl
+++ b/src/erleans.erl
@@ -84,6 +84,8 @@ placement(Module) ->
 %% else return the default.
 -spec fun_or_default(module(), atom(), term()) -> term().
 fun_or_default(Module, FunctionName, Default) ->
+    %% load the module if it isn't already
+    erlang:function_exported(Module, module_info, 0) orelse code:ensure_loaded(Module),
     case erlang:function_exported(Module, FunctionName, 0) of
         true ->
             Module:FunctionName();

--- a/src/erleans_grain.erl
+++ b/src/erleans_grain.erl
@@ -317,11 +317,10 @@ finalize_and_stop(State=#state{cb_module=CbModule,
                                cb_state=CbState,
                                etag=ETag}) ->
     %% Save to or delete from backing storage.
-    %% erleans_pm:unregister_name()
+    erleans_pm:unregister_name(Ref, self()),
     case CbModule:deactivate(CbState) of
         {save, NewCbState} ->
             NewETag = replace_state(CbModule, Provider, Id, NewCbState, ETag),
-            erleans_pm:unregister_name(Ref, self()),
             {stop, normal, State#state{cb_state=NewCbState,
                                        etag=NewETag}};
         {ok, NewCbState} ->

--- a/test/dist_lifecycle_SUITE.erl
+++ b/test/dist_lifecycle_SUITE.erl
@@ -22,12 +22,9 @@ all() ->
 
 init_per_suite(Config) ->
     application:load(erleans),
-    code:ensure_loaded(stream_test_grain),
-    code:ensure_loaded(erleans_consumer_grain),
     application:load(partisan),
     application:load(lasp),
     application:set_env(partisan, peer_port, 10200),
-    code:ensure_loaded(test_grain),
     {ok, _} = application:ensure_all_started(erleans),
     start_nodes(),
     Config.
@@ -64,14 +61,11 @@ start_nodes([{Node, PeerPort} | T], Acc) ->
                                        {application, load, [partisan]},
                                        {application, set_env, [partisan, peer_port, PeerPort]},
                                        {application, load, [erleans]},
-                                       {code, ensure_loaded, [test_grain]},
                                        {application, ensure_all_started, [erleans]}]},
                                      {erl_flags, ErlFlags}]),
     ct:print("\e[32m Node ~p [OK] \e[0m", [HostNode]),
     net_kernel:connect(?NODE_A),
     rpc:call(?NODE_A, partisan_peer_service, join, [{?NODE_CT, "127.0.0.1", 10200}]),
-    rpc:call(?NODE_A, code, ensure_loaded, [stream_test_grain]),
-    rpc:call(?NODE_A, code, ensure_loaded, [erleans_consumer_grain]),
     ok = lasp_peer_service:join({?NODE_A, "127.0.0.1", PeerPort}),
     start_nodes(T, [HostNode | Acc]).
 

--- a/test/grain_lifecycle_SUITE.erl
+++ b/test/grain_lifecycle_SUITE.erl
@@ -18,8 +18,6 @@ all() ->
     [manual_start_stop, bad_etag_save, ephemeral_state].
 
 init_per_suite(Config) ->
-    code:ensure_loaded(test_grain),
-    code:ensure_loaded(test_ephemeral_state_grain),
     application:load(erleans),
     %% set a really low lease time for testing deactivations
     application:set_env(erleans, default_lease_time, 1),
@@ -92,6 +90,6 @@ ephemeral_state(_Config) ->
     %% and increment the activated counter
     ?assertEqual({ok, 2}, test_ephemeral_state_grain:activated_counter(Grain)),
     %% But ephemeral counter should be 0 again
-    ?assertEqual({ok, 0}, test_ephemeral_state_grain:ephemeral_counter(Grain)),
+    ?UNTIL({ok, 0} =:= test_ephemeral_state_grain:ephemeral_counter(Grain)),
 
     ok.

--- a/test/grain_streams_SUITE.erl
+++ b/test/grain_streams_SUITE.erl
@@ -18,8 +18,6 @@ all() ->
     [simple_subscribe].
 
 init_per_suite(Config) ->
-    code:ensure_loaded(stream_test_grain),
-    code:ensure_loaded(erleans_consumer_grain),
     application:load(erleans),
     application:set_env(erleans, default_lease_time, 60000),
     {ok, _} = application:ensure_all_started(erleans),

--- a/test/stateless_grain_SUITE.erl
+++ b/test/stateless_grain_SUITE.erl
@@ -18,8 +18,7 @@ all() ->
     [limits].
 
 init_per_suite(Config) ->
-    code:ensure_loaded(stateless_test_grain),
-    application:load(erleans),    
+    application:load(erleans),
     {ok, _} = application:ensure_all_started(erleans),
     Config.
 


### PR DESCRIPTION
Fixes #13 

It would be nice if `function_exports` were to start loading the module if it weren't already, something to bring up with the OTP team. But for now, this is good enough.