### PR TITLE
retry grain request if grain deactivates while waiting

### DIFF
--- a/test/grain_lifecycle_SUITE.erl
+++ b/test/grain_lifecycle_SUITE.erl
@@ -88,7 +88,7 @@ ephemeral_state(_Config) ->
 
     %% sending message by asking for the counter again will re-activate grain
     %% and increment the activated counter
-    ?assertEqual({ok, 2}, test_ephemeral_state_grain:activated_counter(Grain)),
+    ?assertMatch({ok, N} when N > 1, test_ephemeral_state_grain:activated_counter(Grain)),
     %% But ephemeral counter should be 0 again
     ?assertEqual({ok, 0}, test_ephemeral_state_grain:ephemeral_counter(Grain)),
 

--- a/test/grain_lifecycle_SUITE.erl
+++ b/test/grain_lifecycle_SUITE.erl
@@ -90,6 +90,6 @@ ephemeral_state(_Config) ->
     %% and increment the activated counter
     ?assertEqual({ok, 2}, test_ephemeral_state_grain:activated_counter(Grain)),
     %% But ephemeral counter should be 0 again
-    ?UNTIL({ok, 0} =:= test_ephemeral_state_grain:ephemeral_counter(Grain)),
+    ?assertEqual({ok, 0}, test_ephemeral_state_grain:ephemeral_counter(Grain)),
 
     ok.


### PR DESCRIPTION
Not positive about how we want to do this. Partially doing this now to see if it fixes a race condition test in `ephemeral_state` test.